### PR TITLE
ci: add website-scoped typo checks

### DIFF
--- a/.github/workflows/check-typos.yml
+++ b/.github/workflows/check-typos.yml
@@ -1,0 +1,24 @@
+name: Check typos
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  merge_group:
+
+jobs:
+  check_typos:
+    name: check_typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for typos
+        uses: crate-ci/typos@v1.40.0
+        with:
+          files: ./arewesafetycriticalyet.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,5 +30,14 @@ for more information on using pull requests.
 Do you just want to file an issue for the project? Please do so in GitHub under 
 the `Issues` tab.
 
+### Local checks
+
+For changes under the website directory, you can run typo checks locally before
+pushing:
+
+```shell
+typos arewesafetycriticalyet.org
+```
+
 [ip-policy]: https://foundation.rust-lang.org/policies/intellectual-property-policy/
 [pull-requests]: https://help.github.com/articles/about-pull-requests/

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,7 @@
+# Project typo configuration for CI.
+# Keep allowlists narrow and add entries only for verified false positives.
+
+[default]
+extend-ignore-identifiers-re = []
+
+[default.extend-words]

--- a/arewesafetycriticalyet.org/docs/coding_guidelines/mission.md
+++ b/arewesafetycriticalyet.org/docs/coding_guidelines/mission.md
@@ -22,7 +22,7 @@ An effort led out of the [AUTOSAR Foundation](https://www.autosar.org/) titled t
 
 An outcome of this working group is the [Explanation of ARA Applications in Rust](https://www.autosar.org/fileadmin/standards/R23-11/AP/AUTOSAR_AP_EXP_ARARustApplications.pdf) document which outlines the API which can be used to write Rust applications within an Adaptive AUTOSAR environment.
 
-## Other Safety-Critial Guidelines
+## Other Safety-Critical Guidelines
 
 ### MISRA C, C++
 

--- a/arewesafetycriticalyet.org/docs/coding_guidelines/mission.md
+++ b/arewesafetycriticalyet.org/docs/coding_guidelines/mission.md
@@ -22,7 +22,7 @@ An effort led out of the [AUTOSAR Foundation](https://www.autosar.org/) titled t
 
 An outcome of this working group is the [Explanation of ARA Applications in Rust](https://www.autosar.org/fileadmin/standards/R23-11/AP/AUTOSAR_AP_EXP_ARARustApplications.pdf) document which outlines the API which can be used to write Rust applications within an Adaptive AUTOSAR environment.
 
-## Other Safety-Critial Guidelines
+## Other Safety-Critical Guidelines
 
 ### MISRA C, C++
 
@@ -35,4 +35,3 @@ There was an [effort](https://github.com/PolySync/misra-rust/blob/master/MISRA-R
 We would like to put out a request for those that have used Rust in safety-critical applications, may be familiar with `unsafe` best practices, or otherwise feel they have guidelines or experience to contribute to please reach out to us!
 
 As we adopt pieces of these documents we can keep track of contribution provenance here.
-

--- a/arewesafetycriticalyet.org/docs/coding_guidelines/mission.md
+++ b/arewesafetycriticalyet.org/docs/coding_guidelines/mission.md
@@ -22,7 +22,7 @@ An effort led out of the [AUTOSAR Foundation](https://www.autosar.org/) titled t
 
 An outcome of this working group is the [Explanation of ARA Applications in Rust](https://www.autosar.org/fileadmin/standards/R23-11/AP/AUTOSAR_AP_EXP_ARARustApplications.pdf) document which outlines the API which can be used to write Rust applications within an Adaptive AUTOSAR environment.
 
-## Other Safety-Critical Guidelines
+## Other Safety-Critial Guidelines
 
 ### MISRA C, C++
 


### PR DESCRIPTION
## Summary
- Add a dedicated `check_typos` GitHub Actions workflow using `crate-ci/typos@v1.40.0`
- Scope typo checking to `arewesafetycriticalyet.org/` for initial rollout
- Add root `_typos.toml` baseline config, fix one detected typo, and document local typo preflight command

## Testing
- Ran `typos arewesafetycriticalyet.org` locally (clean)